### PR TITLE
Add gitignore and fix Python modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+.venv/
+# Editor directories and files
+.vscode/
+.idea/
+*.swp
+*~
+.DS_Store
+Thumbs.db
+

--- a/app/agent/llm.py
+++ b/app/agent/llm.py
@@ -3,7 +3,10 @@ from langchain.prompts import PromptTemplate
 
 from ..config import settings
 
-PROMPT_TEMPLATE = """You are Jarvis, a helpful bilingual assistant. Respond in the language of the user (English or Dutch).\n{history}\nUser: {input}\nJarvis:"""
+PROMPT_TEMPLATE = (
+    """You are Jarvis, a helpful bilingual assistant. Respond in the language of the user (English or Dutch).\n"
+    "{history}\nUser: {input}\nJarvis:"""
+)
 
 prompt = PromptTemplate(
     input_variables=["history", "input"],

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from langchain.chains import ConversationChain
 from langchain.memory import ConversationBufferMemory
 
 from .agent.llm import get_llm, prompt
-
+from .memory.vector_memory import get_vector_store
 from .memory.graph_memory import get_driver, save_interaction
 
 app = FastAPI(title="Jarvis API")
@@ -23,7 +23,8 @@ class ChatRequest(BaseModel):
 @app.post("/chat")
 async def chat(request: ChatRequest):
     try:
-
+        response = await chain.apredict(input=request.message)
+        save_interaction(neo4j_driver, request.message, response)
         return {"response": response}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/app/memory/graph_memory.py
+++ b/app/memory/graph_memory.py
@@ -10,4 +10,16 @@ def get_driver():
     )
 
 
+def save_interaction(driver, user_message: str, ai_message: str) -> None:
+    """Persist a user/assistant message pair to Neo4j."""
+    with driver.session() as session:
+        session.run(
+            "MERGE (u:User {id: 1}) "
+            "CREATE (u)-[:SENT]->(:Message {text: $user_msg}) "
+            "CREATE (u)-[:RECEIVED]->(:Message {text: $ai_msg})",
+            user_msg=user_message,
+            ai_msg=ai_message,
+        )
+
+
 

--- a/app/memory/vector_memory.py
+++ b/app/memory/vector_memory.py
@@ -1,0 +1,11 @@
+from chromadb import PersistentClient
+from langchain.vectorstores import Chroma
+from langchain.embeddings import HuggingFaceEmbeddings
+
+
+def get_vector_store() -> Chroma:
+    """Return a Chroma vector store backed by a persistent client."""
+    client = PersistentClient(path="./chroma")
+    embeddings = HuggingFaceEmbeddings()
+    return Chroma(client=client, embedding_function=embeddings)
+


### PR DESCRIPTION
## Summary
- add gitignore rules for caches, editors and virtualenvs
- clean up `llm.py` string formatting
- implement simple vector store and graph memory
- connect chat endpoint to conversation chain

## Testing
- `python -m py_compile app/main.py app/agent/llm.py app/memory/vector_memory.py app/memory/graph_memory.py`

## Summary by Sourcery

Introduce persistent vector and graph memory layers, connect them to the chat endpoint for storing interactions, and add .gitignore rules while cleaning up prompt formatting.

New Features:
- Add .gitignore rules for caches, editors, and virtualenvs
- Implement a persistent Chroma vector store for memory
- Add graph-based memory persistence in Neo4j for user and assistant messages
- Integrate the conversation chain with the /chat endpoint and persist interactions

Enhancements:
- Refactor PROMPT_TEMPLATE string formatting in llm.py