### PR TITLE
Implement ChromaDB and Neo4j logging

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from langchain.memory import ConversationBufferMemory
 from .agent.llm import get_llm, prompt
 
 from .memory.graph_memory import get_driver, save_interaction
+from .memory.vector_memory import get_vector_store, add_message
 
 app = FastAPI(title="Jarvis API")
 
@@ -23,6 +24,13 @@ class ChatRequest(BaseModel):
 @app.post("/chat")
 async def chat(request: ChatRequest):
     try:
+        user_message = request.message
+        response = chain.predict(input=user_message)
+
+        # Persist messages
+        add_message(vector_store, user_message)
+        add_message(vector_store, response)
+        save_interaction(neo4j_driver, user_message, response)
 
         return {"response": response}
     except Exception as e:

--- a/app/memory/graph_memory.py
+++ b/app/memory/graph_memory.py
@@ -10,4 +10,10 @@ def get_driver():
     )
 
 
-
+def save_interaction(driver, user_message: str, ai_message: str):
+    """Log an interaction to Neo4j."""
+    query = (
+        "CREATE (:Interaction {user_message: $user_message, ai_message: $ai_message})"
+    )
+    with driver.session() as session:
+        session.run(query, user_message=user_message, ai_message=ai_message)

--- a/app/memory/vector_memory.py
+++ b/app/memory/vector_memory.py
@@ -1,0 +1,19 @@
+from chromadb import HttpClient
+from uuid import uuid4
+from urllib.parse import urlparse
+
+from ..config import settings
+
+
+def get_vector_store():
+    """Create and return a ChromaDB client."""
+    url = urlparse(settings.chroma_db_url)
+    host = url.hostname or "localhost"
+    port = url.port or 8000
+    return HttpClient(host=host, port=port)
+
+
+def add_message(client, message: str):
+    """Store a message in ChromaDB."""
+    collection = client.get_or_create_collection("messages")
+    collection.add(documents=[message], ids=[str(uuid4())])


### PR DESCRIPTION
## Summary
- add ChromaDB helper and Neo4j logger
- update `/chat` endpoint to persist messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Persist chat interactions by integrating ChromaDB for vector storage and Neo4j for graph logging, and updating the /chat endpoint to save messages to both stores

New Features:
- Add ChromaDB client helper and add_message function to store chat messages in a vector database
- Introduce save_interaction function to log user-AI message pairs as Interaction nodes in Neo4j
- Update /chat endpoint to persist both incoming user messages and AI responses to the configured ChromaDB and Neo4j stores