### PR TITLE
Update vector memory

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,15 @@
-
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from langchain.chains import ConversationChain
 from langchain.memory import ConversationBufferMemory
 
 from .agent.llm import get_llm, prompt
-
-from .memory.graph_memory import get_driver, save_interaction
+from .memory.vector_memory import (
+    get_vector_store,
+    add_conversation_snippet,
+    query_conversation_snippets,
+)
+from .memory.graph_memory import get_driver
 
 app = FastAPI(title="Jarvis API")
 
@@ -20,16 +23,19 @@ chain = ConversationChain(llm=get_llm(), memory=memory, prompt=prompt)
 class ChatRequest(BaseModel):
     message: str
 
+
 @app.post("/chat")
 async def chat(request: ChatRequest):
     try:
-
+        response = chain.predict(input=request.message)
+        add_conversation_snippet(request.message, {"role": "user"})
+        add_conversation_snippet(response, {"role": "assistant"})
         return {"response": response}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)
-
-

--- a/app/memory/vector_memory.py
+++ b/app/memory/vector_memory.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse
+import uuid
+
+import chromadb
+from langchain.embeddings import OllamaEmbeddings
+
+from ..config import settings
+
+EMBED_MODEL = "nomic-embed-text"
+
+
+def _get_client() -> chromadb.HttpClient:
+    parsed = urlparse(settings.chroma_db_url)
+    return chromadb.HttpClient(host=parsed.hostname, port=parsed.port)
+
+
+def get_vector_store(collection_name: str = "conversations") -> chromadb.Collection:
+    client = _get_client()
+    return client.get_or_create_collection(name=collection_name)
+
+
+def add_conversation_snippet(
+    text: str,
+    metadata: dict | None = None,
+    collection_name: str = "conversations",
+) -> None:
+    collection = get_vector_store(collection_name)
+    embedder = OllamaEmbeddings(base_url=settings.ollama_base_url, model=EMBED_MODEL)
+    vector = embedder.embed_query(text)
+    collection.add(
+        ids=[str(uuid.uuid4())],
+        documents=[text],
+        embeddings=[vector],
+        metadatas=[metadata or {}],
+    )
+
+
+def query_conversation_snippets(
+    query: str,
+    n_results: int = 5,
+    collection_name: str = "conversations",
+) -> list[dict]:
+    collection = get_vector_store(collection_name)
+    embedder = OllamaEmbeddings(base_url=settings.ollama_base_url, model=EMBED_MODEL)
+    query_vector = embedder.embed_query(query)
+    results = collection.query(
+        query_embeddings=[query_vector],
+        n_results=n_results,
+        include=["documents", "metadatas", "distances"],
+    )
+    matches = []
+    for rid, doc, meta, dist in zip(
+        results.get("ids", [[]])[0],
+        results.get("documents", [[]])[0],
+        results.get("metadatas", [[]])[0],
+        results.get("distances", [[]])[0],
+    ):
+        matches.append({"id": rid, "text": doc, "metadata": meta, "distance": dist})
+    return matches


### PR DESCRIPTION
## Summary
- connect to Chroma using HttpClient with `settings.chroma_db_url`
- store and query conversation snippets via helper functions
- log snippets in main chat endpoint

## Testing
- `python -m py_compile app/main.py app/memory/vector_memory.py`

## Summary by Sourcery

Enable vector-based memory by integrating ChromaDB for embedding and persisting conversation snippets, and update the chat endpoint to log user and assistant messages.

New Features:
- Introduce a vector_memory module to connect to ChromaDB via HTTP and manage vector stores
- Add helper functions to embed, store, and query conversation snippets using Ollama embeddings
- Log user and assistant messages to the vector store in the chat endpoint

Enhancements:
- Refactor chat endpoint to separate model prediction from snippet logging