### PR TITLE
Implement graph memory interaction saving

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from langchain.memory import ConversationBufferMemory
 from .agent.llm import get_llm, prompt
 
 from .memory.graph_memory import get_driver, save_interaction
+from .memory.vector_memory import get_vector_store
 
 app = FastAPI(title="Jarvis API")
 
@@ -23,7 +24,9 @@ class ChatRequest(BaseModel):
 @app.post("/chat")
 async def chat(request: ChatRequest):
     try:
-
+        user_message = request.message
+        response = chain.predict(input=user_message)
+        save_interaction(neo4j_driver, user_message, response)
         return {"response": response}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/app/memory/graph_memory.py
+++ b/app/memory/graph_memory.py
@@ -10,4 +10,20 @@ def get_driver():
     )
 
 
+def save_interaction(driver, user_message: str, response: str) -> None:
+    """Persist a conversation turn to Neo4j."""
+
+    def _write(tx, user_msg: str, resp: str) -> None:
+        tx.run(
+            """
+            MERGE (u:Message {text: $user_msg, role: 'user'})
+            MERGE (a:Message {text: $resp, role: 'assistant'})
+            MERGE (u)-[:ANSWERED_BY]->(a)
+            """,
+            user_msg=user_msg,
+            resp=resp,
+        )
+
+    with driver.session() as session:
+        session.execute_write(_write, user_message, response)
 

--- a/app/memory/vector_memory.py
+++ b/app/memory/vector_memory.py
@@ -1,0 +1,12 @@
+from chromadb import HttpClient
+from langchain.embeddings import OllamaEmbeddings
+from langchain.vectorstores import Chroma
+
+from ..config import settings
+
+
+def get_vector_store():
+    """Return a LangChain vector store connected to the configured Chroma DB."""
+    client = HttpClient(host=settings.chroma_db_url)
+    embeddings = OllamaEmbeddings(base_url=settings.ollama_base_url, model="llama3")
+    return Chroma(client=client, embedding_function=embeddings)


### PR DESCRIPTION
## Summary
- enable vector memory configuration
- add helper to save chat interactions to Neo4j
- use the new helper from `/chat`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Enable vector memory configuration, add a Neo4j-backed save_interaction helper, and integrate it into the chat endpoint to persist user-assistant turns.

New Features:
- Enable vector memory store via LangChain and Chroma
- Add save_interaction helper to persist chat turns to Neo4j
- Invoke save_interaction in the chat endpoint