### PR TITLE
Remove unused globals and clean requirements

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,3 @@
-
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from langchain.chains import ConversationChain
@@ -6,12 +5,7 @@ from langchain.memory import ConversationBufferMemory
 
 from .agent.llm import get_llm, prompt
 
-from .memory.graph_memory import get_driver, save_interaction
-
 app = FastAPI(title="Jarvis API")
-
-vector_store = get_vector_store()
-neo4j_driver = get_driver()
 
 memory = ConversationBufferMemory()
 chain = ConversationChain(llm=get_llm(), memory=memory, prompt=prompt)
@@ -23,7 +17,7 @@ class ChatRequest(BaseModel):
 @app.post("/chat")
 async def chat(request: ChatRequest):
     try:
-
+        response = chain.predict(input=request.message)
         return {"response": response}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ uvicorn
 langchain
 chromadb
 neo4j
-langdetect


### PR DESCRIPTION
## Summary
- clean up `app/main.py`
- remove unused global variables
- delete unused `langdetect` dependency

## Testing
- `python -m py_compile app/main.py app/agent/llm.py app/config.py app/memory/graph_memory.py app/memory/vector_memory.py`
- `python -m compileall -q app`

## Summary by Sourcery

Remove unused globals and unused dependency, and fix chat endpoint to properly generate responses

Bug Fixes:
- Add missing chain.predict call in chat endpoint to correctly produce a response

Enhancements:
- Remove unused global vector_store and neo4j_driver from app/main.py
- Delete langdetect dependency from requirements.txt