### PR TITLE
Fix application setup and configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app ./app
-
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,10 @@
-
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from langchain.chains import ConversationChain
 from langchain.memory import ConversationBufferMemory
 
 from .agent.llm import get_llm, prompt
-
+from .memory.vector_memory import get_vector_store
 from .memory.graph_memory import get_driver, save_interaction
 
 app = FastAPI(title="Jarvis API")
@@ -20,16 +19,17 @@ chain = ConversationChain(llm=get_llm(), memory=memory, prompt=prompt)
 class ChatRequest(BaseModel):
     message: str
 
+
 @app.post("/chat")
 async def chat(request: ChatRequest):
     try:
-
+        response = chain.predict(input=request.message)
+        save_interaction(neo4j_driver, request.message, response)
         return {"response": response}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)
-
-

--- a/app/memory/graph_memory.py
+++ b/app/memory/graph_memory.py
@@ -10,4 +10,12 @@ def get_driver():
     )
 
 
-
+def save_interaction(driver: GraphDatabase.driver, user_message: str, assistant_message: str) -> None:
+    """Persist a conversation turn in Neo4j."""
+    query = (
+        "MERGE (c:Conversation {id: 1}) "
+        "CREATE (u:Message {text: $user, role: 'user'})-[:PART_OF]->(c) "
+        "CREATE (a:Message {text: $assistant, role: 'assistant'})-[:PART_OF]->(c)"
+    )
+    with driver.session() as session:
+        session.execute_write(lambda tx: tx.run(query, user=user_message, assistant=assistant_message))

--- a/app/memory/vector_memory.py
+++ b/app/memory/vector_memory.py
@@ -1,0 +1,8 @@
+from chromadb import HttpClient
+
+from ..config import settings
+
+
+def get_vector_store() -> HttpClient:
+    """Return a ChromaDB HTTP client connected to the configured server."""
+    return HttpClient(host=settings.chroma_db_url)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,12 @@ services:
     build: .
     ports:
       - "8000:8000"
-
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434
+      - CHROMA_DB_URL=http://chroma:8000
+      - NEO4J_URI=bolt://neo4j:7687
+      - NEO4J_USER=neo4j
+      - NEO4J_PASSWORD=password
     depends_on:
       - chroma
       - neo4j


### PR DESCRIPTION
## Summary
- run `uvicorn` explicitly in the Docker image
- wire database and Ollama URLs from docker-compose environment variables
- store interactions in Neo4j and connect to Chroma
- implement basic vector store and graph memory helpers
- fix `chat` endpoint implementation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- *(fails: `docker-compose` not installed)*

## Summary by Sourcery

Configure application services via Docker Compose environment variables, add Neo4j and ChromaDB memory backends, fix the chat endpoint implementation, and set Uvicorn as the container entrypoint.

New Features:
- Persist chat interactions to Neo4j as graph data
- Integrate ChromaDB HTTP client for vector storage
- Load Ollama, ChromaDB, and Neo4j connection URLs from environment

Bug Fixes:
- Correct the /chat endpoint to use the conversation chain and save each interaction

Enhancements:
- Add helper modules for vector and graph memory operations

Deployment:
- Explicitly run Uvicorn in the Docker container via CMD