### PR TITLE
Fix main imports and resource initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,12 +3,16 @@ from pydantic import BaseModel
 from langchain.chains import ConversationChain
 from langchain.memory import ConversationBufferMemory
 
-from .agent.llm import get_llm, prompt
+from .agent.llm import get_llm, PROMPT_TEMPLATE
 from .memory.vector_memory import get_vector_store
 from .memory.graph_memory import get_driver, save_interaction
-from .memory.vector_memory import get_vector_store
 
 app = FastAPI(title="Jarvis API")
+
+neo4j_driver = get_driver()
+vector_store = get_vector_store()
+
+prompt = PROMPT_TEMPLATE
 
 memory = ConversationBufferMemory()
 chain = ConversationChain(llm=get_llm(), memory=memory, prompt=prompt)


### PR DESCRIPTION
## Summary
- update `app.main` import to use `PROMPT_TEMPLATE`
- initialize `neo4j_driver` and `vector_store`
- expose `PROMPT_TEMPLATE` as `prompt`
- remove duplicate `get_vector_store` import

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Fix main module imports and resource initialization by correcting prompt import, removing duplicate imports, and initializing Neo4j driver and vector store

Bug Fixes:
- Replace incorrect `prompt` import with `PROMPT_TEMPLATE` from the LLM agent
- Remove duplicate import of `get_vector_store`

Enhancements:
- Initialize `neo4j_driver` and `vector_store` at application startup
- Expose `PROMPT_TEMPLATE` as `prompt` for the conversation chain