### PR TITLE
Add MIT license and resolve merge conflict

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jarvis2.0 Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ uvicorn app.main:app --reload
 Then POST to `/chat` with a JSON body containing `message`.
 
 For more details on the overall architecture, see `architectdesign.md`.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/app/main.py
+++ b/app/main.py
@@ -1,26 +1,8 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-<<<<<<< HEAD
-from langchain.chains import ConversationChain
-from langchain.memory import ConversationBufferMemory
-
-from .agent.llm import get_llm, PROMPT_TEMPLATE
-from .memory.vector_memory import get_vector_store
-from .memory.graph_memory import get_driver, save_interaction
-
-app = FastAPI(title="Jarvis API")
-
-neo4j_driver = get_driver()
-vector_store = get_vector_store()
-
-prompt = PROMPT_TEMPLATE
-
-memory = ConversationBufferMemory()
-prompt = PromptTemplate.from_template(PROMPT_TEMPLATE)
-chain = ConversationChain(llm=get_llm(), memory=memory, prompt=prompt)
-=======
 from .agent.llm import get_llm
 from .memory.graph_memory import get_driver, save_interaction
+from .memory.vector_memory import get_vector_store
 
 
 class SimpleChain:
@@ -32,12 +14,10 @@ class SimpleChain:
     async def apredict(self, input: str) -> str:
         return self.llm.generate(input)
 
+
 app = FastAPI(title="Jarvis API")
 
 chain = SimpleChain(llm=get_llm())
-neo4j_driver = get_driver()
->>>>>>> 252e2ddc9a1672d39c1b99ea8dae0a4142951264
-
 neo4j_driver = get_driver()
 vector_store = get_vector_store()
 


### PR DESCRIPTION
## Summary
- fix merge conflict markers in `app/main.py`
- add MIT license
- reference the license from the README

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Resolve merge conflicts in app/main.py, streamline chain setup into a SimpleChain implementation, and add the MIT license.

Enhancements:
- Remove merge conflict markers and consolidate the chain implementation into a SimpleChain
- Replace ConversationChain setup with a simplified SimpleChain import and instantiation

Documentation:
- Add MIT license reference in README

Chores:
- Include the MIT license file in the repository