### PR TITLE
Fix main module and add shutdown handler

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,24 +1,6 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-<<<<<<< HEAD
-from langchain.chains import ConversationChain
-from langchain.memory import ConversationBufferMemory
 
-from .agent.llm import get_llm, PROMPT_TEMPLATE
-from .memory.vector_memory import get_vector_store
-from .memory.graph_memory import get_driver, save_interaction
-
-app = FastAPI(title="Jarvis API")
-
-neo4j_driver = get_driver()
-vector_store = get_vector_store()
-
-prompt = PROMPT_TEMPLATE
-
-memory = ConversationBufferMemory()
-prompt = PromptTemplate.from_template(PROMPT_TEMPLATE)
-chain = ConversationChain(llm=get_llm(), memory=memory, prompt=prompt)
-=======
 from .agent.llm import get_llm
 from .memory.graph_memory import get_driver, save_interaction
 
@@ -32,14 +14,11 @@ class SimpleChain:
     async def apredict(self, input: str) -> str:
         return self.llm.generate(input)
 
+
 app = FastAPI(title="Jarvis API")
 
 chain = SimpleChain(llm=get_llm())
 neo4j_driver = get_driver()
->>>>>>> 252e2ddc9a1672d39c1b99ea8dae0a4142951264
-
-neo4j_driver = get_driver()
-vector_store = get_vector_store()
 
 
 class ChatRequest(BaseModel):
@@ -55,6 +34,13 @@ async def chat(request: ChatRequest):
         return {"response": response}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.on_event("shutdown")
+def shutdown_event() -> None:
+    """Close the Neo4j driver if it was created."""
+    if neo4j_driver is not None:
+        neo4j_driver.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix merge conflict leftovers in `app/main.py`
- keep `SimpleChain` variant that aligns with tests
- add FastAPI shutdown handler that closes the Neo4j driver

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Fix remnants of a merge conflict in the main FastAPI module and ensure the Neo4j driver is closed on shutdown.

Bug Fixes:
- Resolve merge conflict leftovers in app/main.py
- Remove duplicate Neo4j driver instantiation

Enhancements:
- Add a FastAPI shutdown event handler to properly close the Neo4j driver