### PR TITLE
Fix chain setup and drop unused vector store

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,24 +1,6 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-<<<<<<< HEAD
-from langchain.chains import ConversationChain
-from langchain.memory import ConversationBufferMemory
 
-from .agent.llm import get_llm, PROMPT_TEMPLATE
-from .memory.vector_memory import get_vector_store
-from .memory.graph_memory import get_driver, save_interaction
-
-app = FastAPI(title="Jarvis API")
-
-neo4j_driver = get_driver()
-vector_store = get_vector_store()
-
-prompt = PROMPT_TEMPLATE
-
-memory = ConversationBufferMemory()
-prompt = PromptTemplate.from_template(PROMPT_TEMPLATE)
-chain = ConversationChain(llm=get_llm(), memory=memory, prompt=prompt)
-=======
 from .agent.llm import get_llm
 from .memory.graph_memory import get_driver, save_interaction
 
@@ -32,14 +14,12 @@ class SimpleChain:
     async def apredict(self, input: str) -> str:
         return self.llm.generate(input)
 
+
 app = FastAPI(title="Jarvis API")
 
+# Initialize dependencies
 chain = SimpleChain(llm=get_llm())
 neo4j_driver = get_driver()
->>>>>>> 252e2ddc9a1672d39c1b99ea8dae0a4142951264
-
-neo4j_driver = get_driver()
-vector_store = get_vector_store()
 
 
 class ChatRequest(BaseModel):

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -10,3 +10,13 @@ def test_chat_endpoint():
     assert response.status_code == 200
     data = response.json()
     assert data == {"response": "Echo: Hello"}
+
+
+def test_multiple_messages():
+    first = client.post("/chat", json={"message": "Hi"})
+    assert first.status_code == 200
+    assert first.json() == {"response": "Echo: Hi"}
+
+    second = client.post("/chat", json={"message": "How are you?"})
+    assert second.status_code == 200
+    assert second.json() == {"response": "Echo: How are you?"}


### PR DESCRIPTION
## Summary
- resolve merge conflict in `app/main.py`
- remove unused `vector_store` and related imports
- keep a simple asynchronous chain using `SimpleLLM`
- extend chat tests to cover multiple requests

## Testing
- `python -m pytest -q tests/test_chat.py::test_chat_endpoint` *(fails: No module named pytest)*

## Summary by Sourcery

Resolve merge conflict, remove unused vector store, simplify chain setup, and extend chat tests

Bug Fixes:
- Resolve merge conflict markers in `app/main.py`

Enhancements:
- Remove unused `vector_store` and related imports
- Simplify chain initialization to use only `SimpleLLM` and Neo4j driver

Tests:
- Add test for multiple consecutive chat requests to verify chat endpoint behavior