### PR TITLE
Resolve merge markers in main.py

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,30 +1,13 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-<<<<<<< HEAD
-from langchain.chains import ConversationChain
-from langchain.memory import ConversationBufferMemory
 
-from .agent.llm import get_llm, PROMPT_TEMPLATE
-from .memory.vector_memory import get_vector_store
-from .memory.graph_memory import get_driver, save_interaction
-
-app = FastAPI(title="Jarvis API")
-
-neo4j_driver = get_driver()
-vector_store = get_vector_store()
-
-prompt = PROMPT_TEMPLATE
-
-memory = ConversationBufferMemory()
-prompt = PromptTemplate.from_template(PROMPT_TEMPLATE)
-chain = ConversationChain(llm=get_llm(), memory=memory, prompt=prompt)
-=======
 from .agent.llm import get_llm
 from .memory.graph_memory import get_driver, save_interaction
+from .memory.vector_memory import get_vector_store
 
 
 class SimpleChain:
-    """Minimal stand-in for ConversationChain."""
+    """Minimal stand-in for a conversation chain."""
 
     def __init__(self, llm):
         self.llm = llm
@@ -32,12 +15,10 @@ class SimpleChain:
     async def apredict(self, input: str) -> str:
         return self.llm.generate(input)
 
+
 app = FastAPI(title="Jarvis API")
 
 chain = SimpleChain(llm=get_llm())
-neo4j_driver = get_driver()
->>>>>>> 252e2ddc9a1672d39c1b99ea8dae0a4142951264
-
 neo4j_driver = get_driver()
 vector_store = get_vector_store()
 


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers
- simplify API chain implementation

## Testing
- `python -m py_compile app/main.py`
- `python -m pytest -q` *(fails: No module named pytest)*

## Summary by Sourcery

Clean up merge conflict remnants and simplify the chain logic in main.py

Bug Fixes:
- Remove stray merge conflict markers from main.py

Enhancements:
- Replace the external ConversationChain with an internal SimpleChain implementation
- Eliminate legacy langchain memory and prompt setup and streamline imports

Chores:
- Reorder and tidy up vector_memory import