### PR TITLE
Add OpenWebUI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ Jarvis 2.0 is a minimal FastAPI-based service that demonstrates a bilingual AI a
    ```bash
    pip install -r requirements.txt
    ```
-3. (Optional) Start the full stack with Docker Compose:
+3. (Optional) Start the full stack with Docker Compose. This will launch the
+   API, databases, Ollama, and OpenWebUI:
    ```bash
    docker compose up --build
    ```
+   Once running, browse to `http://localhost:8080` to access OpenWebUI. The API
+   itself remains available on `http://localhost:8000`.
+   Environment variables such as `OLLAMA_BASE_URL` and `WEBUI_SECRET_KEY` are
+   defined in `docker-compose.yml` and mirror the settings expected by
+   `app/config.py`.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,17 @@ services:
       - NEO4J_AUTH=neo4j/password
     volumes:
       - neo4j_data:/data
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    ports:
+      - "8080:8080"
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434
+      - WEBUI_SECRET_KEY=change-me
+    volumes:
+      - open_webui_data:/app/backend/data
+    depends_on:
+      - ollama
   ollama:
     image: ollama/ollama
     volumes:
@@ -32,3 +43,4 @@ volumes:
   chroma_data:
   neo4j_data:
   ollama_data:
+  open_webui_data:


### PR DESCRIPTION
## Summary
- include OpenWebUI container in `docker-compose.yml`
- document OpenWebUI endpoint and environment vars in `README`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*

## Summary by Sourcery

Integrate the OpenWebUI service into the application's Docker Compose setup and update the README with usage instructions and environment variable details.

New Features:
- Add OpenWebUI container to the Docker Compose configuration.

Documentation:
- Document OpenWebUI endpoint and required environment variables in the README.