### PR TITLE
Remove unused vector store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jarvis 2.0
 
-Jarvis 2.0 is a minimal FastAPI-based service that demonstrates a bilingual AI assistant. It uses a simple LLM implementation and includes optional vector and graph memory backends.
+Jarvis 2.0 is a minimal FastAPI-based service that demonstrates a bilingual AI assistant. It uses a simple LLM implementation and includes an optional graph memory backend. A vector store helper is provided but not used in the default API.
 
 ## Setup
 

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,6 @@ from pydantic import BaseModel
 
 from .agent.llm import get_llm
 from .memory.graph_memory import get_driver, save_interaction
-from .memory.vector_memory import get_vector_store
 
 
 class SimpleChain:

--- a/tests/test_vector_memory_unused.py
+++ b/tests/test_vector_memory_unused.py
@@ -1,0 +1,6 @@
+def test_vector_store_not_initialized():
+    import sys
+    import importlib
+    import app.main
+    assert 'app.memory.vector_memory' not in sys.modules
+    assert not hasattr(app.main, 'get_vector_store')


### PR DESCRIPTION
## Summary
- drop vector store import from main API
- document that the vector store is optional and unused by default
- add a unit test ensuring the vector store is not initialized

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Remove the unused vector store from the default API, clarify its optional status in docs, and add a test to ensure it isn’t initialized

Enhancements:
- Drop the unused vector store import from the main application module
- Document in README that the vector store helper is optional and not used by default

Documentation:
- Update README to reflect optional vector store usage and emphasize graph memory backend

Tests:
- Add a unit test to confirm the vector store module is not imported or initialized by default