### PR TITLE
Switch to async Neo4j driver

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -32,17 +32,17 @@ async def chat(request: ChatRequest):
     try:
         response = await chain.apredict(input=request.message)
         if neo4j_driver is not None:
-            save_interaction(neo4j_driver, request.message, response)
+            await save_interaction(neo4j_driver, request.message, response)
         return {"response": response}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 
 @app.on_event("shutdown")
-def shutdown_event() -> None:
+async def shutdown_event() -> None:
     """Close the Neo4j driver if it was created."""
     if neo4j_driver is not None:
-        neo4j_driver.close()
+        await neo4j_driver.close()
 
 
 if __name__ == "__main__":

--- a/app/memory/graph_memory.py
+++ b/app/memory/graph_memory.py
@@ -1,27 +1,27 @@
 try:
-    from neo4j import GraphDatabase
+    from neo4j import AsyncGraphDatabase
 except ImportError:  # pragma: no cover - neo4j not installed in testing env
-    GraphDatabase = None
+    AsyncGraphDatabase = None
 
 from ..config import settings
 
 
 def get_driver():
-    """Return a Neo4j driver if available."""
-    if GraphDatabase is None:
+    """Return a Neo4j async driver if available."""
+    if AsyncGraphDatabase is None:
         return None
-    return GraphDatabase.driver(
+    return AsyncGraphDatabase.driver(
         settings.neo4j_uri,
         auth=(settings.neo4j_user, settings.neo4j_password),
     )
 
 
-def save_interaction(driver, user_message: str, ai_message: str) -> None:
+async def save_interaction(driver, user_message: str, ai_message: str) -> None:
     """Persist a user/assistant message pair to Neo4j."""
     if driver is None:
         return
-    with driver.session() as session:
-        session.run(
+    async with driver.session() as session:
+        await session.run(
             "MERGE (u:User {id: 1}) "
             "CREATE (u)-[:SENT]->(:Message {text: $user_msg}) "
             "CREATE (u)-[:RECEIVED]->(:Message {text: $ai_msg})",

--- a/tests/test_graph_memory.py
+++ b/tests/test_graph_memory.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.memory.graph_memory import save_interaction
 
 
@@ -5,7 +7,7 @@ class FakeSession:
     def __init__(self):
         self.calls = []
 
-    def run(self, query, **params):
+    async def run(self, query, **params):
         self.calls.append((query, params))
 
 
@@ -17,20 +19,50 @@ class FakeDriver:
         driver = self
 
         class CM:
-            def __enter__(self_inner):
+            async def __aenter__(self_inner):
                 return driver.session_obj
 
-            def __exit__(self_inner, exc_type, exc, tb):
+            async def __aexit__(self_inner, exc_type, exc, tb):
                 pass
 
         return CM()
 
+    async def close(self):
+        pass
 
-def test_save_interaction_stores_messages():
+
+@pytest.mark.asyncio
+async def test_save_interaction_stores_messages():
     driver = FakeDriver()
-    save_interaction(driver, "hi", "bye")
+    await save_interaction(driver, "hi", "bye")
     assert len(driver.session_obj.calls) == 1
     query, params = driver.session_obj.calls[0]
     assert "MERGE" in query
     assert params["user_msg"] == "hi"
     assert params["ai_msg"] == "bye"
+
+
+class FailingSession:
+    async def run(self, query, **params):
+        raise RuntimeError("boom")
+
+
+class FailingDriver:
+    def session(self):
+        session = FailingSession()
+
+        class CM:
+            async def __aenter__(self_inner):
+                return session
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                pass
+
+        return CM()
+
+
+@pytest.mark.asyncio
+async def test_save_interaction_raises_on_failure():
+    driver = FailingDriver()
+    with pytest.raises(RuntimeError):
+        await save_interaction(driver, "hi", "bye")


### PR DESCRIPTION
## Summary
- use `AsyncGraphDatabase` for graph memory
- await writes to Neo4j in the `/chat` endpoint
- ensure the driver closes asynchronously at shutdown
- refactor graph memory unit test and add failure case

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Switch Neo4j integration to use the async driver throughout the application and update associated endpoint, shutdown logic, and tests.

Enhancements:
- Use AsyncGraphDatabase for the Neo4j driver and update get_driver accordingly
- Convert save_interaction to an async function using async session context and await session.run
- Await save_interaction in the chat endpoint to ensure writes complete
- Make the shutdown_event handler async and await driver.close

Tests:
- Refactor graph_memory unit tests to async pytest functions
- Add a test case for save_interaction to raise on session.run failure