### PR TITLE
Add vector memory tests

### DIFF
--- a/app/memory/vector_memory.py
+++ b/app/memory/vector_memory.py
@@ -3,8 +3,8 @@ from langchain.vectorstores import Chroma
 from langchain.embeddings import HuggingFaceEmbeddings
 
 
-def get_vector_store() -> Chroma:
+def get_vector_store(path: str = "./chroma") -> Chroma:
     """Return a Chroma vector store backed by a persistent client."""
-    client = PersistentClient(path="./chroma")
+    client = PersistentClient(path=path)
     embeddings = HuggingFaceEmbeddings()
     return Chroma(client=client, embedding_function=embeddings)

--- a/tests/test_vector_memory.py
+++ b/tests/test_vector_memory.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+import pytest
+
+chromadb = pytest.importorskip("chromadb")
+
+from langchain.vectorstores import Chroma
+from app.memory import vector_memory
+
+
+class FakeEmbeddings:
+    """Deterministic dummy embeddings for testing."""
+
+    def embed_documents(self, texts):
+        return [self.embed_query(t) for t in texts]
+
+    def embed_query(self, text):
+        return [float(len(text))]
+
+
+def test_add_and_retrieve_document(tmp_path, monkeypatch):
+    monkeypatch.setattr(vector_memory, "HuggingFaceEmbeddings", lambda: FakeEmbeddings())
+    store = vector_memory.get_vector_store(path=str(tmp_path))
+    store.add_texts(["hello world"], ids=["1"])
+    results = store.similarity_search("hello", k=1)
+    assert results
+    assert results[0].page_content == "hello world"
+    # cleanup
+    store._client.reset()
+


### PR DESCRIPTION
## Summary
- parameterize `get_vector_store` so path can be specified
- add regression test for Chroma vector store

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Allow specifying the storage path for the Chroma vector store and add a test to ensure vector memory functionality works as expected

Enhancements:
- Parameterize get_vector_store to accept a custom path for the Chroma client

Tests:
- Add regression test for Chroma vector store to verify document addition and retrieval using deterministic fake embeddings