### PR TITLE
Add .env example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment configuration for Jarvis
+# Copy this file to `.env` and adjust the values as needed.
+OLLAMA_BASE_URL=http://ollama:11434
+CHROMA_DB_URL=http://chroma:8000
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Jarvis 2.0 is a minimal FastAPI-based service that demonstrates a bilingual AI a
    ```bash
    pip install -r requirements.txt
    ```
-3. (Optional) Start the full stack with Docker Compose:
+3. Copy `.env.example` to `.env` and update the values if needed.
+   The required variables are documented in that file.
+4. (Optional) Start the full stack with Docker Compose:
    ```bash
    docker compose up --build
    ```


### PR DESCRIPTION
## Summary
- document required environment variables in `.env.example`
- reference `.env.example` in README setup instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Add .env.example and update README setup instructions to reference and document required environment variables

Documentation:
- Introduce `.env.example` file listing required environment variables.
- Update README to instruct copying `.env.example` to `.env` and reference the example file in setup instructions.