### PR TITLE
Fix imports in test_chat

### DIFF
--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,9 +1,9 @@
 from fastapi.testclient import TestClient
 
-import app.main
-from app.main import app
+import app.main as jarvis_main
+from app.main import app as fastapi_app
 
-client = TestClient(app)
+client = TestClient(fastapi_app)
 
 
 def test_chat_endpoint():
@@ -17,8 +17,8 @@ def test_chat_error_handling(monkeypatch):
     async def raise_error(*args, **kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(app.main.chain, "apredict", raise_error)
-    error_client = TestClient(app)
+    monkeypatch.setattr(jarvis_main.chain, "apredict", raise_error)
+    error_client = TestClient(fastapi_app)
     resp = error_client.post("/chat", json={"message": "Hi"})
     assert resp.status_code == 500
     assert resp.json() == {"detail": "boom"}


### PR DESCRIPTION
## Summary
- import FastAPI instance as `fastapi_app`
- adjust `TestClient` instantiation and monkeypatching to reference `fastapi_app` and `jarvis_main`

## Testing
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Tests:
- Import FastAPI instance as fastapi_app, alias app.main as jarvis_main, and update TestClient and monkeypatch usage in test_chat.py