### PR TITLE
Remove unused imports from vector memory tests

### DIFF
--- a/tests/test_vector_memory.py
+++ b/tests/test_vector_memory.py
@@ -1,10 +1,8 @@
-import os
-import tempfile
+# ruff: noqa: E402
 import pytest
 
 chromadb = pytest.importorskip("chromadb")
 
-from langchain.vectorstores import Chroma
 from app.memory import vector_memory
 
 

--- a/tests/test_vector_memory_unused.py
+++ b/tests/test_vector_memory_unused.py
@@ -1,6 +1,5 @@
 def test_vector_store_not_initialized():
     import sys
-    import importlib
     import app.main
     assert 'app.memory.vector_memory' not in sys.modules
     assert not hasattr(app.main, 'get_vector_store')


### PR DESCRIPTION
## Summary
- clean up unused imports in `tests/test_vector_memory.py`
- move imports under `pytest.importorskip` and silence E402
- remove unused import from `tests/test_vector_memory_unused.py`

## Testing
- `ruff check tests`
- `pytest -q` *(fails: `pytest` not installed)*