### PR TITLE
Fix BaseSettings Config subclass error

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,7 @@ class Settings(BaseSettings):
     neo4j_user: str = "neo4j"
     neo4j_password: str = "password"
 
-    class Config:
+    class Config(BaseSettings.Config):
         env_file = ".env"
 
 


### PR DESCRIPTION
## Summary
- extend `Config` from `BaseSettings.Config` to remove pyright error

## Testing
- `pyright`

## Summary by Sourcery

Bug Fixes:
- Extend Settings.Config to inherit from BaseSettings.Config to remove Pyright error