### PR TITLE
Fix legacy prompt import errors

### DIFF
--- a/app/agent/llm.py
+++ b/app/agent/llm.py
@@ -11,6 +11,12 @@ PROMPT_TEMPLATE = (
     "{history}\nUser: {input}\nJarvis:"
 )
 
+# ``prompt`` previously exposed a ``PromptTemplate`` from LangChain. The current
+# minimal implementation no longer relies on LangChain, but other modules may
+# still attempt to import ``prompt``. Provide a simple string fallback to avoid
+# import errors if older code expects this name.
+prompt = PROMPT_TEMPLATE
+
 
 def get_llm() -> SimpleLLM:
     """Return the LLM instance."""


### PR DESCRIPTION
## Summary
- avoid docker failures when older code tries to import `prompt`
- expose a simple fallback `prompt` constant

## Testing
- `pip install -r requirements.txt && pip install -r requirements-dev.txt` *(fails: no network)*
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Bug Fixes:
- Add `prompt` alias pointing to the existing prompt template to prevent import failures in older modules