### PR TITLE
Update README with jarvis.sh usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,30 @@ Jarvis 2.0 is a minimal FastAPI-based service that demonstrates a bilingual AI a
    pip install -r requirements-dev.txt
    ```
 
+4. Build and start the Docker services:
    ```bash
    docker compose up --build
    ```
    Once running, browse to `http://localhost:8080` to access OpenWebUI. The API
    itself remains available on `http://localhost:8000`.
+
    Environment variables such as `OLLAMA_BASE_URL` and `WEBUI_SECRET_KEY` are
    defined in `docker-compose.yml` and mirror the settings expected by
    `app/config.py`.
+
+## Configuration
+
+Copy `.env.example` to `.env` and update the values to point at your own
+services. At a minimum you should review the following variables:
+
+- `OLLAMA_BASE_URL` - URL for the Ollama LLM service.
+- `CHROMA_DB_URL` - URL for the ChromaDB vector store (if used).
+- `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD` - connection settings for the
+  Neo4j graph database.
+- `WEBUI_SECRET_KEY` - secret key for securing OpenWebUI sessions.
+
+These environment variables must be configured before running the containers so
+that Jarvis can connect to the required services.
 
 ## Usage
 
@@ -30,6 +46,20 @@ Run the API locally:
 uvicorn app.main:app --reload
 ```
 Then POST to `/chat` with a JSON body containing `message`.
+
+### Using `jarvis.sh`
+
+The `jarvis.sh` helper script bundles a few convenience steps. Run it from the
+project root to build and launch the Docker services and monitor their logs:
+
+```bash
+./jarvis.sh
+```
+
+It first compiles the Python files, verifies that Docker and `docker-compose`
+are installed, and then brings the containers up in the background. Any error
+messages from the services will be collected in `error.log` while the script
+streams the combined logs to your terminal.
 
 For more details on the overall architecture, see `architectdesign.md`.
 


### PR DESCRIPTION
## Summary
- document how to run docker compose via `jarvis.sh`
- fix numbered list in setup section

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `ruff check .`
- `pytest -q` *(fails: command not found)*

## Summary by Sourcery

Update README to improve developer setup instructions and document the `jarvis.sh` helper script usage

Documentation:
- Add Docker Compose build and startup steps with port details
- Introduce a Configuration section describing required environment variables
- Document the `jarvis.sh` script, including its pre-flight checks and log handling
- Fix numbering in the setup list